### PR TITLE
Fixed dependence

### DIFF
--- a/bin/webserver/Dockerfile
+++ b/bin/webserver/Dockerfile
@@ -35,7 +35,7 @@ RUN docker-php-ext-install -j$(nproc) intl
 
 RUN docker-php-ext-install mbstring
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng12-dev
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ 
 RUN docker-php-ext-install -j$(nproc) gd
 


### PR DESCRIPTION
libpng12-dev --> libpng-dev

The package libpng12-dev was dropped after 16.04. 

More info: https://askubuntu.com/questions/991706/e-package-libpng12-dev-has-no-installation-candidate